### PR TITLE
Fix/add uint8clampedarray conversion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject siili-core/blurhash "0.0.3"
+(defproject siili-core/blurhash "0.0.4"
   :description "A Clojure(Script) implementation of the blurhash algorithm"
   :url "http://github.com/siili-core/blurhash"
   :license {:name "MIT License"

--- a/src/blurhash/encode.cljc
+++ b/src/blurhash/encode.cljc
@@ -1,10 +1,10 @@
 (ns blurhash.encode
-  #?(:cljs (:require-macros [blurhash.util :as util]))
   (:require
     [blurhash.util :as util]
     [blurhash.util :as util]
     [blurhash.base83 :as base83]
-    [clojure.string :as s]))
+    [clojure.string :as s])
+  #?(:cljs (:require-macros [blurhash.util :as util])))
 
 (defn encode-component [i j height width norm-factor image-linear]
   (let [comp-data (for [y (range height)

--- a/src/blurhash/util.cljc
+++ b/src/blurhash/util.cljc
@@ -32,3 +32,14 @@
 
 (defmacro forv [& body]
   `(vec (for ~@body)))
+
+#?(:cljs
+   (defn ->Uint8ClampedArray [pixels]
+     "This is of course terribly slow. Optimization of the data structures
+     is a priority."
+     (->> v
+          (map #(for [pixel %]
+                  (conj pixel 255)))
+          (reduce #(into %1 (flatten %2)) [])
+          (new js/Uint8ClampedArray))))
+


### PR DESCRIPTION
Add a function for converting the pixel array to Uint8ClampedArray in ClojureScript, so that the blurred image can be rendered on HTML canvas.

This very slow, so we'll have to return to this in #2.