### PR TITLE
Remove reflection (#9), optimize decoding in ClojureScript (partial solution for #2)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject siili-core/blurhash "0.0.5"
+(defproject siili-core/blurhash "0.0.6"
   :description "A Clojure(Script) implementation of the blurhash algorithm"
   :url "http://github.com/siili-core/blurhash"
   :license {:name "MIT License"

--- a/src/blurhash/core.clj
+++ b/src/blurhash/core.clj
@@ -1,5 +1,6 @@
 (ns blurhash.core
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [blurhash.decode :refer [decode]])
   (:import (java.awt.image BufferedImage)
            (java.io File)
            (java.awt Color)
@@ -17,6 +18,7 @@
                       (vector (.getRed rgb-object)
                               (.getGreen rgb-object)
                               (.getBlue rgb-object)))))))
+
 
 (defn pixels->file [pixels ^String filename]
   (let [height (count pixels)

--- a/src/blurhash/core.clj
+++ b/src/blurhash/core.clj
@@ -1,6 +1,5 @@
 (ns blurhash.core
-  (:require [clojure.java.io :as io]
-            [blurhash.decode :refer [decode]])
+  (:require [clojure.java.io :as io])
   (:import (java.awt.image BufferedImage)
            (java.io File)
            (java.awt Color)

--- a/src/blurhash/core.clj
+++ b/src/blurhash/core.clj
@@ -18,15 +18,15 @@
                               (.getGreen rgb-object)
                               (.getBlue rgb-object)))))))
 
-(defn pixels->file [pixels filename]
+(defn pixels->file [pixels ^String filename]
   (let [height (count pixels)
         width (count (first pixels))
         output-image (new BufferedImage width height BufferedImage/TYPE_INT_RGB)
         _ (doseq [row-index    (range height)
                   column-index (range width)]
-            (let [[r g b] (nth (nth pixels row-index) column-index)
+            (let [[^Integer r ^Integer g ^Integer b] (nth (nth pixels row-index) column-index)
                   color (.getRGB (new Color r g b))]
-              (.setRGB output-image column-index row-index (.intValue color))))]
+              (.setRGB output-image column-index row-index color)))]
     (ImageIO/write
       output-image
       "jpg"

--- a/src/blurhash/decode.cljc
+++ b/src/blurhash/decode.cljc
@@ -71,5 +71,5 @@
         {:keys [size-x size-y]} (decode-components blurhash)
         colors (get-colors blurhash size-x size-y (get-real-maxval blurhash punch))]
     (for [y (range h)]
-        (util/forv [x (range w)]
-          (decode-pixel x y size-x size-y colors w h linear)))))
+      (for [x (range w)]
+        (decode-pixel x y size-x size-y colors w h linear)))))

--- a/src/blurhash/decode.cljc
+++ b/src/blurhash/decode.cljc
@@ -1,8 +1,7 @@
 (ns blurhash.decode
-  #?(:cljs (:require-macros [blurhash.util :as util]))
-  (:require
-    [blurhash.util :as util]
-    [blurhash.base83 :as base83]))
+  (:require [blurhash.util :as util]
+            [blurhash.base83 :as base83])
+  #?(:cljs (:require-macros [blurhash.util :as util])))
 
 (defn decode-dc [value]
   (mapv util/srgb->linear
@@ -64,12 +63,32 @@
 
   The optional `punch` tunes the contrast of the image.
   If you want the image to be decoded into a matrix of linear floating-point
-  values, set the `linear` parameter to `true`."
+  values, set the `linear` parameter to `true`.
+
+  In Clojure, this function returns a picture represented as nested vectors.
+  In ClojureScipt, it is returned as an Uint8ClampedArray that can be rendered
+  into HTML canvas."
   [blurhash w h & [punch linear]]
   (let [punch (or punch 1.0)
         linear (or linear false)
         {:keys [size-x size-y]} (decode-components blurhash)
         colors (get-colors blurhash size-x size-y (get-real-maxval blurhash punch))]
-    (for [y (range h)]
-      (for [x (range w)]
-        (decode-pixel x y size-x size-y colors w h linear)))))
+    #?(:clj
+       (for [y (range h)]
+         (for [x (range w)]
+           (decode-pixel x y size-x size-y colors w h linear))))
+    #?(:cljs
+       (let [se (for [y (range h)
+                      x (range w)]
+                  (decode-pixel x y size-x size-y colors w h linear))]
+         (->> se
+              (reduce (fn [col itm]
+                        (loop [c col
+                               i itm]
+                          (if (empty? i)
+                            (conj! c 255)
+                            (recur (conj! c (first i))
+                                   (rest i)))))
+                      (transient []))
+              persistent!
+              (new js/Uint8ClampedArray))))))

--- a/src/blurhash/encode.cljc
+++ b/src/blurhash/encode.cljc
@@ -70,7 +70,7 @@
          max-ac-comp (->> components
                           rest
                           flatten
-                          (map #(Math/abs %))
+                          (map #(Math/abs ^Double %))
                           (apply max))
          dc-value (encode-dc (first components))
          quant-max-ac-comp (max 0

--- a/src/blurhash/util.cljc
+++ b/src/blurhash/util.cljc
@@ -35,10 +35,14 @@
 
 #?(:cljs
    (defn ->Uint8ClampedArray [pixels]
-     "This is of course terribly slow. Optimization of the data structures
+     "This is of course slow. Optimization of the data structures
      is a priority."
      (->> pixels
           (map #(for [pixel %]
                   (conj pixel 255)))
           (reduce #(into %1 (flatten %2)) [])
           (new js/Uint8ClampedArray))))
+
+#?(:cljs
+   (defn Uint8ClampedArray->vec [uint8]
+     (vec (.from js/Array uint8))))

--- a/src/blurhash/util.cljc
+++ b/src/blurhash/util.cljc
@@ -26,7 +26,7 @@
 
 (defn sign-pow
   "Sign-preserving exponentiation."
-  [v exp]
+  [^Double v exp]
   (* (if (neg? v) -1 1)
      (Math/pow (Math/abs v) exp)))
 

--- a/test/clj/blurhash/core_test.clj
+++ b/test/clj/blurhash/core_test.clj
@@ -18,15 +18,10 @@
     (when (.isFile temp-file)
       (io/delete-file temp-file))))
 
-; (use-fixtures :once with-temp-file-cleaned)
+(use-fixtures :once with-temp-file-cleaned)
 
 (deftest file->pixels-test
   (let [blurred-matrix (file->pixels blurred-test-file-name)]
-    #_(testing "Pixels in the matrix from the read file match the computed values"
-      (is (= [158 169 150] (first (first blurred-matrix))))
-      (is (= [159 145 124] (first (last blurred-matrix))))
-      (is (= [148 134 138] (last (last blurred-matrix))))
-      (is (= [191 180 180] (nth (second blurred-matrix) 200))))
     (testing "Dimensions match"
       (is (= 236 (count blurred-matrix)))
       (is (= 300 (count (first blurred-matrix)))))))
@@ -35,6 +30,6 @@
   (testing "Round-tripping (file->matrix->file)"
     (let [orig (file->pixels test-file-name)
           round-tripped (do
-                          (write-matrix-to-image orig temporary-file)
+                          (pixels->file orig temporary-file)
                           (file->pixels temporary-file))]
       (is (= orig round-tripped)))))

--- a/test/cljc/blurhash/decode_test.cljc
+++ b/test/cljc/blurhash/decode_test.cljc
@@ -1,5 +1,6 @@
 (ns blurhash.decode-test
   (:require [blurhash.decode :as d]
+            [blurhash.util :as util]
             [clojure.string :refer [join]]
             [clojure.test :refer [deftest testing is]]))
 
@@ -7,12 +8,19 @@
   "UIGuXeS@x[xX_MORbuoy?uNGM{nTNHMzIVnn")
 
 (deftest decode-test
-  (let [pic (d/decode test-hash 300 236)]
-    (testing "Dimensions are right"
-      (is (= 236 (count pic)))
-      (is (= 300 (count (first pic)))))
-    (testing "Content looks right"
-      (is (= [158 169 150] (first (first pic)))))))
+  #?(:clj
+     (let [pic (d/decode test-hash 300 236)]
+       (testing "Dimensions are right"
+         (is (= 236 (count pic)))
+         (is (= 300 (count (first pic)))))
+       (testing "Content looks right"
+         (is (= [158 169 150] (first (first pic))))))))
+  #?(:cljs
+     (testing "Dimensions look right"
+       (is (= (* 236 300 4) (-> test-hash
+                                (d/decode 300 236)
+                                util/Uint8ClampedArray->vec
+                                count)))))
 
 (deftest helper-tests
   (let [real-max-val (d/get-real-maxval test-hash 1.0)]


### PR DESCRIPTION
This PR will remove reflection warnings and speeds up decoding in Cljs. The decode function also now returns a Uint8ClampedArray that can be rendered into HTML as is. Conversions between representations are not needed after this.